### PR TITLE
fix: wrong tx hash for create contract request

### DIFF
--- a/evm/ethrpc/api_backend.go
+++ b/evm/ethrpc/api_backend.go
@@ -321,6 +321,7 @@ func (e *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	txReq := &evm.TxRequest{
 		Input:    signedTx.Data(),
 		Origin:   sender,
+		Address:  signedTx.To(),
 		GasLimit: signedTx.Gas(),
 		GasPrice: signedTx.GasPrice(),
 		Value:    signedTx.Value(),
@@ -328,9 +329,6 @@ func (e *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 		V:        v,
 		R:        r,
 		S:        s,
-	}
-	if signedTx.To() != nil {
-		txReq.Address = *signedTx.To()
 	}
 	byt, err := json.Marshal(txReq)
 	logrus.Printf("SendTx, Request=%+v\n", string(byt))
@@ -355,12 +353,11 @@ func yuTxn2EthTxn(yuSignedTxn *yutypes.SignedTxn) *types.Transaction {
 
 	// if nonce is assigned to signedTx.Raw.Nonce, then this is ok; otherwise it's nil:
 	nonce := yuSignedTxn.Raw.Nonce
-
 	tx := types.NewTx(&types.LegacyTx{
 		Nonce:    nonce,
 		GasPrice: txReq.GasPrice,
 		Gas:      txReq.GasLimit, // gasLimit: should be obtained from Block & Settings
-		To:       &txReq.Address,
+		To:       txReq.Address,
 		Value:    txReq.Value,
 		Data:     txReq.Input,
 		V:        txReq.V,

--- a/evm/types.go
+++ b/evm/types.go
@@ -22,16 +22,16 @@ type CallResponse struct {
 }
 
 type TxRequest struct {
-	Input    []byte         `json:"input"`
-	Address  common.Address `json:"address"`
-	Origin   common.Address `json:"origin"`
-	GasLimit uint64         `json:"gasLimit"`
-	GasPrice *big.Int       `json:"gasPrice"`
-	Value    *big.Int       `json:"value"`
-	Hash     common.Hash    `json:"hash"`
-	V        *big.Int       `json:"v"`
-	R        *big.Int       `json:"r"`
-	S        *big.Int       `json:"s"`
+	Input    []byte          `json:"input"`
+	Address  *common.Address `json:"address"`
+	Origin   common.Address  `json:"origin"`
+	GasLimit uint64          `json:"gasLimit"`
+	GasPrice *big.Int        `json:"gasPrice"`
+	Value    *big.Int        `json:"value"`
+	Hash     common.Hash     `json:"hash"`
+	V        *big.Int        `json:"v"`
+	R        *big.Int        `json:"r"`
+	S        *big.Int        `json:"s"`
 }
 
 type CreateRequest struct {


### PR DESCRIPTION
When creating a contract, the calculation of its Transaction Hash is incorrect.

<img width="658" alt="image" src="https://github.com/user-attachments/assets/f6957aba-fa75-4fef-aa3e-3293e435dcce">

The correct transaction should has `to=nil`, but the wrong transaction has `to=0x00..00`, so the tx hash is wrong.