### PR TITLE
check if tx is already existed when create new tx

### DIFF
--- a/evm/ethrpc/api_backend.go
+++ b/evm/ethrpc/api_backend.go
@@ -316,6 +316,17 @@ func (e *EthAPIBackend) Call(ctx context.Context, args TransactionArgs, blockNrO
 }
 
 func (e *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+	// Check if this tx has been created
+	exist, _, _, _, _, _ := e.GetTransaction(ctx, signedTx.Hash())
+	if exist {
+		return ErrAlreadyKnown
+	}
+	existedTx := e.GetPoolTransaction(signedTx.Hash())
+	if existedTx != nil {
+		return ErrAlreadyKnown
+	}
+
+	// Create Tx
 	signer := types.NewEIP155Signer(e.ethChainCfg.ChainID)
 	sender, err := types.Sender(signer, signedTx)
 	if err != nil {

--- a/evm/ethrpc/errors.go
+++ b/evm/ethrpc/errors.go
@@ -1,11 +1,19 @@
 package ethrpc
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// From geth/core/txpool/errors
+var (
+	// ErrAlreadyKnown is returned if the transactions is already contained
+	// within the pool.
+	ErrAlreadyKnown = errors.New("already known")
 )
 
 // revertError is an API error that encompasses an EVM revert with JSON error


### PR DESCRIPTION
For the same request, when it is sent repeatedly, the error message "already known" should be returned.